### PR TITLE
fix bug (file name not found)

### DIFF
--- a/lib/Transformer/FieldValue/FileFieldValueTransformer.php
+++ b/lib/Transformer/FieldValue/FileFieldValueTransformer.php
@@ -35,21 +35,24 @@ class FileFieldValueTransformer implements FieldValueTransformerInterface
     ) {
         /** @var \Ibexa\Core\FieldType\BinaryFile\Value $fieldValue */
         $fieldValue = $content->getFieldValue($fieldIdentifier);
+        if (isset($fieldValue->fileName)) {
+            $routeReference = $this->routeReferenceGenerator->generate(
+                ContentDownloadRouteReferenceListener::ROUTE_NAME,
+                [
+                    ContentDownloadRouteReferenceListener::OPT_CONTENT => $content,
+                    ContentDownloadRouteReferenceListener::OPT_VERSION => $content->getVersionInfo()->versionNo,
+                    ContentDownloadRouteReferenceListener::OPT_FIELD_IDENTIFIER => $fieldIdentifier,
+                ]
+            );
+            $downloadUri = $this->router->generate(
+                $routeReference->getRoute(),
+                $routeReference->getParams(),
+                UrlGeneratorInterface::ABSOLUTE_URL
+            );
 
-        $routeReference = $this->routeReferenceGenerator->generate(
-            ContentDownloadRouteReferenceListener::ROUTE_NAME,
-            [
-                ContentDownloadRouteReferenceListener::OPT_CONTENT => $content,
-                ContentDownloadRouteReferenceListener::OPT_VERSION => $content->getVersionInfo()->versionNo,
-                ContentDownloadRouteReferenceListener::OPT_FIELD_IDENTIFIER => $fieldIdentifier,
-            ]
-        );
-        $downloadUri = $this->router->generate(
-            $routeReference->getRoute(),
-            $routeReference->getParams(),
-            UrlGeneratorInterface::ABSOLUTE_URL
-        );
+            return new File($fieldValue->fileName, $fieldValue->fileSize, $fieldValue->mimeType, $downloadUri);
+        }
 
-        return new File($fieldValue->fileName, $fieldValue->fileSize, $fieldValue->mimeType, $downloadUri);
+        return null;
     }
 }


### PR DESCRIPTION
Bug;

An exception has been thrown during the rendering of a template ("Parameter "filename" for route "ibexa.content.download" must match "[^/]++" ("" given) to generate a corresponding URL.").